### PR TITLE
fix for cimg_no_system_calls

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -5786,6 +5786,7 @@ namespace cimg_library {
     inline int system(const char *const command, const char *const module_name=0, const bool is_verbose=false) {
       cimg::unused(module_name);
 #ifdef cimg_no_system_calls
+      cimg::unused(command,is_verbose);
       return -1;
 #else
 


### PR DESCRIPTION
small fix for  `cimg_no_system_calls`

example for iOS 
I can't build  with `-Werror`

```
#ifdef __APPLE__
    #include <TargetConditionals.h>
    #ifdef TARGET_OS_IPHONE
        // iOS, tvOS, or watchOS device
        #define cimg_no_system_calls
    #endif
#endif

#include <CImg.h>
```

```
error: unused parameter 'command' [-Werror,-Wunused-parameter]
error: unused parameter 'is_verbose' [-Werror,-Wunused-parameter]
```