### PR TITLE
Addresses issue #415

### DIFF
--- a/plugins/jpeg_buffer.h
+++ b/plugins/jpeg_buffer.h
@@ -234,7 +234,8 @@ static CImg get_load_jpeg_buffer(const JOCTET *const buffer, const unsigned buff
   jpeg_start_decompress(&cinfo);
 
   const unsigned int row_stride = cinfo.output_width * cinfo.output_components;
-  JOCTET *buf = new JOCTET[cinfo.output_width*cinfo.output_height*cinfo.output_components];
+  const size_t siz = safe_size(cinfo.output_width,cinfo.output_height,1,cinfo.output_components);
+  JOCTET *buf = new JOCTET[siz];
   const JOCTET *buf2 = buf;
   JSAMPROW row_pointer[1];
   while (cinfo.output_scanline < cinfo.output_height) {


### PR DESCRIPTION
Hello,

The only change follows what I described in my comment under the issue. To summarize, for 32 bit it is possible to purposefully tamper with certain jpg header fields leading to the size of a heap allocation to be miscalculated due to integer overflow. 

All this change does is use the existing `CImg::safe_size()` to throw an exception in case the calculations performed using the relevant `cinfo` fields lead to an integer overflow. This will consequentially prevent the crash I was able to produce from happening with the provided `use_jpeg_buffer.cpp` example, and the possibility for heap corruption caused by out of bounds memory access.

Thanks!