### PR TITLE
Fix compiler errors

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -79,6 +79,7 @@
 #include <climits>
 #include <ctime>
 #include <exception>
+#include <algorithm>
 #define cimg_str(x) #x
 #define cimg_str2(x) cimg_str(x)
 


### PR DESCRIPTION
The STL declares `std::min` and `std::max` functions in the "algorithm" header.

Some libraries such as libmagick++ has already included "algorithm", that's why the code can be compiled if we use these libraries or build project with cmake. However, if we don't use these libraries and use the `cing::min/max` functions (or other functions use cimg::min/max) , then we will encounter compiler errors.

![errors](https://github.com/user-attachments/assets/cf5dea61-6927-45fd-bc65-6b78293af2ed)

So add algorithm back.

P.S. Another option is to define cimg's own two-argument version of the min and max functions. But this violates the DRY principle.
