### PR TITLE
Fix examples building for CMake 4.0

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,7 +39,7 @@
 #  knowledge of the CeCILL license and that you accept its terms.
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 
 PROJECT(Examples-CIMG)

--- a/examples/gaussian_fit1d.cpp
+++ b/examples/gaussian_fit1d.cpp
@@ -82,7 +82,7 @@ int main(int argc,char **argv) {
   float f_amp = 1, f_mean = 1, f_std = 1, f_lambda = f_lambda0;
   if (f_params) std::sscanf(f_params,"%f%*c%f%*c%f",&f_amp,&f_mean,&f_std);
   else {
-    const float& vmax = samples.get_shared_row(1).max();
+    const float vmax = samples.get_shared_row(1).max();
     float cmax = 0; samples.contains(vmax,cmax);
     f_mean = samples((int)cmax,0);
     f_std = (s_xmax - s_xmin)/10;


### PR DESCRIPTION
![Snipaste_2025-05-28_12-01-05](https://github.com/user-attachments/assets/be9f9953-88d0-4e29-b31e-58e4386f054a)

Also fix a c++ variable liftime issue in the example code:

![Snipaste_2025-05-28_18-05-10](https://github.com/user-attachments/assets/2327e5a1-550a-433a-a4c3-0ef48b9d1d82)
