### PR TITLE
Fix unused warnings of is_multithreaded_rendering

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -54617,6 +54617,9 @@ namespace cimg_library {
                             const float specular_lightness, const float specular_shininess,
                             const float g_opacity, const float sprite_scale,
                             const bool is_multithreaded_rendering) {
+#if cimg_use_openmp == 0
+      cimg::unused(is_multithreaded_rendering);
+#endif
       typedef typename to::value_type _to;
       if (is_empty() || !vertices || !primitives) return *this;
       CImg<char> error_message(1024);


### PR DESCRIPTION
I'm not using openmp so I get this warning:

<img width="981" alt="image" src="https://github.com/user-attachments/assets/97f2fc9a-9dc7-4d0a-a98b-bb692ecfc1f4" />

Just ignore it when openmp is disabled.