### PR TITLE
Fix for libheif v1.20.2

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -59506,7 +59506,7 @@ namespace cimg_library {
           S = handle.has_alpha_channel()?4:3;
         assign(W,H,1,S);
 
-#if LIBHEIF_NUMERIC_VERSION < LIBHEIF_MAKE_VERSION(1, 20, 0)
+#if LIBHEIF_NUMERIC_VERSION < LIBHEIF_MAKE_VERSION(1, 20, 0) || LIBHEIF_NUMERIC_VERSION > LIBHEIF_MAKE_VERSION(1, 20, 1)
         int stride = 0;
 #else
         size_t stride = 0;


### PR DESCRIPTION
They change the function back in v1.20.2, it's crazy.
<img width="1203" height="89" alt="image" src="https://github.com/user-attachments/assets/1067f357-845d-4405-a1ae-418de3f454c9" />
